### PR TITLE
Fix boost::asio::io_service forward declarations

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -27,13 +27,10 @@
 #pragma once
 
 #include "core.hpp"
+#include <boost/asio/io_service.hpp>
 #include <functional>
 #include <memory>
 #include <vector>
-
-namespace boost { namespace asio {
-    class io_service;
-}}
 
 namespace munin {
     class component;

--- a/include/server.hpp
+++ b/include/server.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
 #include "core.hpp"
+#include <boost/asio/io_service.hpp>
 #include <functional>
 #include <memory>
-
-namespace boost { namespace asio {
-    class io_service;
-}}
 
 namespace ma {
 

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -2,6 +2,7 @@
 
 #include "core.hpp"
 #include "datastream.hpp"
+#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
Not all versions of Boost have `boost::asio::io_service` declared as a class, so the proper header must be included instead.