### PR TITLE
Updated to Server++ 0.0.2.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class MuninAcceptanceConan(ConanFile):
     exports = "*"
     options = {"shared": [True, False], "withTests": [True, False]}
     default_options = {"shared": False, "withTests": False}
-    requires = ("serverpp/[>=0.0.1]@kazdragon/conan-public",
+    requires = ("serverpp/[>=0.0.2]@kazdragon/conan-public",
                 "telnetpp/[>=2.0.0]@kazdragon/conan-public",
                 "terminalpp/[>=1.3.0]@kazdragon/conan-public",
                 "munin/[>=0.3.1]@kazdragon/conan-public",

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <serverpp/core.hpp>
+#include <boost/asio/io_context.hpp>
 #include <memory>
 
 namespace ma {
@@ -12,10 +13,11 @@ namespace ma {
 class application final
 {
 public :
-    application(serverpp::port_identifier port);
+    application(
+        boost::asio::io_context &io_context,
+        serverpp::port_identifier port);
     ~application();
     
-    void run();
     void shutdown();
 
 private :

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio/io_context.hpp>
 #include <memory>
 
 namespace ma {
@@ -14,6 +15,7 @@ public :
     //* =====================================================================
     explicit client(
         connection &&cnx, 
+        boost::asio::io_context &io_context,
         std::function<void (client const&)> const &connection_died,
         std::function<void ()> const &shutdown);
 
@@ -21,6 +23,11 @@ public :
     /// \brief Destructor
     //* =====================================================================
     ~client();
+
+    //* =====================================================================
+    /// \brief Closes the connection.
+    //* =====================================================================
+    void close();
 
 private :
     class impl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,13 +99,14 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    ma::application application{port};
+    boost::asio::io_context io_context;
+    ma::application application{io_context, port};
 
     std::vector<std::thread> threadpool;
 
     for (unsigned int thr = 0; thr < concurrency; ++thr)
     {
-        threadpool.emplace_back([&application]{application.run();});
+        threadpool.emplace_back([&]{io_context.run();});
     }
     
     for (auto &pthread : threadpool)


### PR DESCRIPTION
Repaint requests from the main state are now scheduled on a strand,
so that if multiple repaint requests are received at once, they can
be coalesced into a single repaint.  This is as opposed to an
entire repaint for every keystroke.