### PR TITLE
CMakeLists.txt now uses target_sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,15 @@ conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
 
 set(CMAKE_CXX_STANDARD 14)
 
-add_executable(textray
-    src/application.cpp
-    src/camera.cpp
-    src/client.cpp
-    src/connection.cpp
-    src/main.cpp
-    src/ui.cpp
+add_executable(textray src/main.cpp)
+
+target_sources(textray
+    PRIVATE
+        src/application.cpp
+        src/camera.cpp
+        src/client.cpp
+        src/connection.cpp
+        src/ui.cpp
 )
 
 target_include_directories(textray

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,13 +1,13 @@
 from conans import ConanFile, CMake, tools
 
 
-class MuninAcceptanceConan(ConanFile):
-    name = "munin-acceptance"
+class TextratConan(ConanFile):
+    name = "textray"
     version = "0.0.1"
     license = "MIT"
     author = "KazDragon"
-    url = "https://github.com/KazDragon/terminalpp"
-    description = "A test bed for Munin, implementing a text-based FPS view"
+    url = "https://github.com/KazDragon/textray"
+    description = "A Telnet server test bed for Munin, implementing a text-based FPS view"
     topics = ("terminal-emulators", "ansi-escape-codes")
     settings = "os", "compiler", "build_type", "arch"
     exports = "*"
@@ -36,5 +36,5 @@ class MuninAcceptanceConan(ConanFile):
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["munin-acceptance"]
+        self.cpp_info.libs = ["textray"]
 


### PR DESCRIPTION
Also removed the last trace of the project's previous name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/textray/13)
<!-- Reviewable:end -->
